### PR TITLE
YouTube Embed Zero Height Fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const divStyle = {
   position: 'relative',
   height: 0,
   overflow: 'hidden',
-  maxWidth: '100%'
+  minWidth: '100%'
 }
 
 const iframeStyle = {


### PR DESCRIPTION
For some reason I'm getting zero height on youtube embeds when using `max-width: 100%` but by changing it to `min-width: 100%` they started rendering just fine. Not sure if this is a problem with other types of embeds but I thought I'd open this just to start a conversation.